### PR TITLE
Add functionality to import Python module attribute from a node in an RDF graph

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+-   repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+    -   id: black

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ description = """
 Tools for managing RDF resources and common metamodels.
 """
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Development Status :: 2 - Pre-Alpha",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,10 +16,11 @@ requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Development Status :: 2 - Pre-Alpha",
-    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"
+    "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)"
 ]
 dependencies = [
   'rdflib',
+  'pyshacl',
   'platformdirs',
 ]
 

--- a/src/rdf_utils/python.py
+++ b/src/rdf_utils/python.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier:  MPL-2.0
+from importlib import import_module
+from rdflib import Namespace, Graph, URIRef
+from rdf_utils.uri import URI_MM_PYTHON
+
+
+NS_MM_PYTHON = Namespace(URI_MM_PYTHON)
+MM_PY_MODULE_NAME = NS_MM_PYTHON["module-name"]
+MM_PY_ATTR_NAME = NS_MM_PYTHON["attribute-name"]
+
+
+def import_attr_from_node(graph: Graph, uri: URIRef):
+    module_name = str(graph.value(uri, MM_PY_MODULE_NAME))
+    attr_name = str(graph.value(uri, MM_PY_ATTR_NAME))
+    return getattr(import_module(module_name), attr_name)

--- a/src/rdf_utils/python.py
+++ b/src/rdf_utils/python.py
@@ -9,7 +9,10 @@ MM_PY_MODULE_NAME = NS_MM_PYTHON["module-name"]
 MM_PY_ATTR_NAME = NS_MM_PYTHON["attribute-name"]
 
 
-def import_attr_from_node(graph: Graph, uri: URIRef):
+def import_attr_from_node(graph: Graph, uri: URIRef | str):
+    if isinstance(uri, str):
+        uri = URIRef(uri)
+
     module_name = str(graph.value(uri, MM_PY_MODULE_NAME))
     attr_name = str(graph.value(uri, MM_PY_ATTR_NAME))
     return getattr(import_module(module_name), attr_name)

--- a/src/rdf_utils/uri.py
+++ b/src/rdf_utils/uri.py
@@ -1,5 +1,10 @@
-# SPDX-License-Identifier:  GPL-3.0-or-later
+# SPDX-License-Identifier:  MPL-2.0
 URL_COMP_ROB2B = "https://comp-rob2b.github.io"
 URL_SECORO = "https://secorolab.github.io"
 URL_SECORO_MM = f"{URL_SECORO}/metamodels"
 URL_SECORO_M = f"{URL_SECORO}/models"
+
+URL_MM_PYTHON_SHACL = f"{URL_SECORO_MM}/languages/python.shacl.ttl"
+URL_MM_PYTHON_JSON = f"{URL_SECORO_MM}/languages/python.json"
+
+URI_MM_PYTHON = f"{URL_SECORO_MM}/languages/python#"

--- a/tests/test_python_model.py
+++ b/tests/test_python_model.py
@@ -2,7 +2,7 @@
 import unittest
 from urllib.request import urlopen
 import pyshacl
-from rdflib import ConjunctiveGraph, URIRef
+from rdflib import ConjunctiveGraph
 from rdf_utils.uri import URL_MM_PYTHON_JSON, URL_MM_PYTHON_SHACL, URL_SECORO_M
 from rdf_utils.resolver import install_resolver
 from rdf_utils.python import import_attr_from_node
@@ -46,7 +46,7 @@ class PythonTest(unittest.TestCase):
         )
         self.assertTrue(conforms, f"SHACL validation failed:\n{report_text}")
 
-        os_path_exists = import_attr_from_node(graph, URIRef(URI_OS_PATH_EXISTS))
+        os_path_exists = import_attr_from_node(graph, URI_OS_PATH_EXISTS)
         self.assertTrue(os_path_exists(self.mm_python_shacl_path))
 
 

--- a/tests/test_python_model.py
+++ b/tests/test_python_model.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier:  MPL-2.0
+import unittest
+from urllib.request import urlopen
+import pyshacl
+from rdflib import ConjunctiveGraph, URIRef
+from rdf_utils.uri import URL_MM_PYTHON_JSON, URL_MM_PYTHON_SHACL, URL_SECORO_M
+from rdf_utils.resolver import install_resolver
+from rdf_utils.python import import_attr_from_node
+
+
+TEST_URL = f"{URL_SECORO_M}/models/tests"
+URI_OS_PATH_EXISTS = f"{TEST_URL}/test-os-path-exists"
+PYTHON_MODEL = f"""
+{{
+    "@context": [
+        "{URL_MM_PYTHON_JSON}"
+    ],
+    "@graph": [
+        {{
+            "@id": "{URI_OS_PATH_EXISTS}", "@type": "py:ModuleAttribute",
+            "py:module-name": "os.path", "py:attribute-name": "exists"
+        }}
+    ]
+}}
+"""
+
+
+class PythonTest(unittest.TestCase):
+    def setUp(self):
+        install_resolver()
+        with urlopen(URL_MM_PYTHON_SHACL) as fp:
+            self.mm_python_shacl_path = fp.file.name
+
+    def test_python_import(self):
+        graph = ConjunctiveGraph()
+        graph.parse(data=PYTHON_MODEL, format="json-ld")
+
+        shacl_g = ConjunctiveGraph()
+        shacl_g.parse(URL_MM_PYTHON_SHACL, format="turtle")
+        conforms, _, report_text = pyshacl.validate(
+            graph,
+            shacl_graph=shacl_g,
+            data_graph_format="json-ld",
+            shacl_graph_format="ttl",
+            inference="rdfs",
+        )
+        self.assertTrue(conforms, f"SHACL validation failed:\n{report_text}")
+
+        os_path_exists = import_attr_from_node(graph, URIRef(URI_OS_PATH_EXISTS))
+        self.assertTrue(os_path_exists(self.mm_python_shacl_path))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier:  GPL-3.0-or-later
+# SPDX-License-Identifier:  MPL-2.0
 import unittest
 from os.path import exists
 from urllib.request import urlopen
@@ -15,9 +15,11 @@ class ResolverTest(unittest.TestCase):
 
     def test_resolver(self):
         with urlopen(TEST_URL) as fp:
-            self.assertTrue(hasattr(fp, 'file'))
-            self.assertTrue(hasattr(fp.file, 'name'))
-            self.assertTrue(exists(fp.file.name), f"resolver did not cache '{TEST_URL}' to '{fp.file.name}'")
+            self.assertTrue(hasattr(fp, "file"))
+            self.assertTrue(hasattr(fp.file, "name"))
+            self.assertTrue(
+                exists(fp.file.name), f"resolver did not cache '{TEST_URL}' to '{fp.file.name}'"
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- add unit test which include checking SHACL constraint and test
  importing functionality
- meant to work with secorolab/metamodels#3
- add pre-commit hook